### PR TITLE
Remove word "Version" from Vyxal release messages

### DIFF
--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -733,7 +733,7 @@ class VyxalBot2(Application):
         
         releaseName = release["name"].lower()
         if event.data["repository"]["name"] == "Vyxal":
-            releaseName = releaseName.replace(" version", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
+            releaseName = releaseName.replace("version ", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
         message = await self.room.send(
             f'__[{event.data["repository"]["name"]} {releaseName}]({release["html_url"]})__'
         )

--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -733,7 +733,7 @@ class VyxalBot2(Application):
         
         releaseName = release["name"].lower()
         # attempt to match version number, otherwise default to previous behaviour
-        if match := re.search("(\d+\.)*\d+", releaseName): 
+        if match := re.search("\d.*", releaseName): 
             releaseName = match[0]
         message = await self.room.send(
             f'__[{event.data["repository"]["name"]} {releaseName}]({release["html_url"]})__'

--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -732,8 +732,9 @@ class VyxalBot2(Application):
         )
         
         releaseName = release["name"].lower()
-        if event.data["repository"]["name"] == "Vyxal":
-            releaseName = releaseName.replace("version ", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
+        # attempt to match version number, otherwise default to previous behaviour
+        if match := re.search("(\d+\.)*\d+", releaseName): 
+            releaseName = match[0]
         message = await self.room.send(
             f'__[{event.data["repository"]["name"]} {releaseName}]({release["html_url"]})__'
         )

--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -730,8 +730,12 @@ class VyxalBot2(Application):
         self.logger.info(
             f'{event.data["sender"]["login"]} released {release["html_url"]}'
         )
+        
+        releaseName = release["name"].lower()
+        if event.data["repository"]["name"] == "Vyxal":
+            releaseName.replace(" version", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
         message = await self.room.send(
-            f'__[{event.data["repository"]["name"]} {release["name"].lower()}]({release["html_url"]})__'
+            f'__[{event.data["repository"]["name"]} {releaseName}]({release["html_url"]})__'
         )
         if event.data["repository"]["name"] in self.config["importantRepositories"]:
             await self.room.pin(message)

--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -733,7 +733,7 @@ class VyxalBot2(Application):
         
         releaseName = release["name"].lower()
         if event.data["repository"]["name"] == "Vyxal":
-            releaseName.replace(" version", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
+            releaseName = releaseName.replace(" version", "") # "Vyxal version x.y.z" -> "Vyxal x.y.z"
         message = await self.room.send(
             f'__[{event.data["repository"]["name"]} {releaseName}]({release["html_url"]})__'
         )


### PR DESCRIPTION
Because it doesn't look very nice in chat, but removing the word "version" from the release on github would break the tradition of 117 releases.