### PR TITLE
Remove spaces in ping command

### DIFF
--- a/vyxalbot2/__init__.py
+++ b/vyxalbot2/__init__.py
@@ -391,7 +391,7 @@ class VyxalBot2(Application):
                 if not len(
                     message := " ".join(
                         [
-                            "@" + user["name"]
+                            "@" + user["name"].replace(" ", "")
                             for user in self.userDB.membersOfGroup(args["group"])
                             if user["id"] != event.user_id
                         ]


### PR DESCRIPTION
It is scientifically proven (p = -1 so p < 0.05) that having whitespace impedes pinging.